### PR TITLE
Add callback whenever a prop scrolls Grid to a row/column/cell

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React components for efficiently rendering large, scrollable lists and tabular data",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "user": "bvaughn",
-  "version": "9.22.3-gitkraken.1",
+  "version": "9.22.3-gitkraken.2",
   "homepage": "https://github.com/bvaughn/react-virtualized",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -59,6 +59,11 @@ type Props = {
    */
   onScroll: (params: Scroll) => void,
 
+  /**
+   * Callback invoked whenever the scrollToRow prop triggers a scrollTop change
+   */
+  onScrollToRowCausedUpdate: (params: Scroll) => void,
+
   /** See Grid#overscanIndicesGetter */
   overscanIndicesGetter: OverscanIndicesGetter,
 
@@ -101,6 +106,7 @@ export default class List extends React.PureComponent<Props> {
     autoHeight: false,
     estimatedRowSize: 30,
     onScroll: () => {},
+    onScrollToRowCausedUpdate: () => {},
     noRowsRenderer: () => null,
     onRowsRendered: () => {},
     overscanIndicesGetter: accessibilityOverscanIndicesGetter,
@@ -201,6 +207,7 @@ export default class List extends React.PureComponent<Props> {
         columnCount={1}
         noContentRenderer={noRowsRenderer}
         onScroll={this._onScroll}
+        onScrollToTargetCausedUpdate={this._onScrollToRowCausedUpdate}
         onSectionRendered={this._onSectionRendered}
         ref={this._setRef}
         scrollToRow={scrollToIndex}
@@ -248,6 +255,16 @@ export default class List extends React.PureComponent<Props> {
     const {onScroll} = this.props;
 
     onScroll({clientHeight, scrollHeight, scrollTop});
+  };
+
+  _onScrollToRowCausedUpdate = ({
+    clientHeight,
+    scrollHeight,
+    scrollTop,
+  }: GridScroll) => {
+    const {onScrollToRowCausedUpdate} = this.props;
+
+    onScrollToRowCausedUpdate({clientHeight, scrollHeight, scrollTop});
   };
 
   _onSectionRendered = ({


### PR DESCRIPTION
Most of the diff is so that `Grid.scrollToCell()` will only call the new callback exactly once. We're not even using that method right now so I'm actually not terribly concerned about it - I am only confirming that our use case with the `scrollToRow` prop is working as intended, the rest is just "hopefully if someone tries this in the future it will probably work" but odds are no one will ever try it.

As far as what we're using TODAY, the important stuff is in List.js and in Grid's `_updateScrollTopForScrollToRow`, as called by the `updateScrollIndexHelper` via `componentDidUpdate`.

The tests are already not passing based on our other existing changes, but I think the linter is passing, and it builds properly, and I've run the build version in GK, so I'm not terribly concerned about the tests.