### PR TITLE
Fix throwing errors during scrollToRow stuff, plus some propType error spam

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "React components for efficiently rendering large, scrollable lists and tabular data",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com>",
   "user": "bvaughn",
-  "version": "9.22.3-gitkraken.2",
+  "version": "9.22.3-gitkraken.3",
   "homepage": "https://github.com/bvaughn/react-virtualized",
   "main": "dist/commonjs/index.js",
   "module": "dist/es/index.js",

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -648,6 +648,7 @@ class Grid extends React.PureComponent<Props, State> {
     const {scrollLeft: oldScrollLeft, scrollTop: oldScrollTop} = this.state;
 
     const props = this.props;
+    const state = this.state;
 
     let newScrollLeft = undefined;
     let newScrollTop = undefined;
@@ -660,6 +661,7 @@ class Grid extends React.PureComponent<Props, State> {
           ...props,
           scrollToColumn: columnIndex,
         },
+        state,
         true,
       );
 
@@ -678,6 +680,7 @@ class Grid extends React.PureComponent<Props, State> {
           ...props,
           scrollToRow: rowIndex,
         },
+        state,
         true,
       );
 

--- a/source/Grid/Grid.js
+++ b/source/Grid/Grid.js
@@ -154,7 +154,7 @@ type Props = {
   /**
    * Callback invoked whenever scrollToRow/Column/Cell triggers a state update.
    */
-  onScrollToTargetCausedUpdate: (params: Scroll) => void,
+  onScrollToTargetCausedUpdate?: (params: Scroll) => void,
 
   /**
    * Called whenever a horizontal or vertical scrollbar is added or removed.

--- a/source/List/List.js
+++ b/source/List/List.js
@@ -62,7 +62,7 @@ type Props = {
   /**
    * Callback invoked whenever the scrollToRow prop triggers a scrollTop change
    */
-  onScrollToRowCausedUpdate: (params: Scroll) => void,
+  onScrollToRowCausedUpdate?: (params: Scroll) => void,
 
   /** See Grid#overscanIndicesGetter */
   overscanIndicesGetter: OverscanIndicesGetter,


### PR DESCRIPTION
The main issue was that sometimes I passed `(props, boolean)` into functions that take `(props, componentState, boolean)`. When this happened, it was exploding trying to access properties on a boolean. When built and linked into GK, this fixes GK-852 and GK-854. (GK-854 might be a little harder to verify because of null-icon error spam; that will also be fixed in the GK PR that bumps this package.)