### PR TITLE
Use the largest integer pixel size that is smaller than the container

### DIFF
--- a/source/AutoSizer/AutoSizer.js
+++ b/source/AutoSizer/AutoSizer.js
@@ -166,9 +166,10 @@ export default class AutoSizer extends React.Component<Props, State> {
       // Guard against AutoSizer component being removed from the DOM immediately after being added.
       // This can result in invalid style values which can result in NaN values if we don't handle them.
       // See issue #150 for more context.
+      const boundingClientRect = this._parentNode.getBoundingClientRect();
 
-      const height = this._parentNode.offsetHeight || 0;
-      const width = this._parentNode.offsetWidth || 0;
+      const height = Math.trunc(boundingClientRect.height) || 0;
+      const width = Math.trunc(boundingClientRect.width) || 0;
 
       const win = this._window || window;
       const style = win.getComputedStyle(this._parentNode) || {};


### PR DESCRIPTION
I can also make this pull request upstream if we want.

This PR addresses the issue in https://github.com/bvaughn/react-virtualized/issues/1287, using the method described by https://github.com/bvaughn/react-virtualized/issues/1287#issuecomment-526314821 . We were running into this problem in the left panel, where the autosizer thought that it was half a pixel larger than its container in some resolutions, causing this to happen:

![image](https://user-images.githubusercontent.com/106114248/235005209-a6237885-9372-4263-ab92-921d2e78b5c9.png)
